### PR TITLE
board / #5/ 게시글 삭제 

### DIFF
--- a/back/routes/board/boardController.js
+++ b/back/routes/board/boardController.js
@@ -156,3 +156,31 @@ exports.PostEdit = async (req,res) => {
     }
     res.json(response)
 };
+
+exports.delete = async (req,res) => {
+    const b_idx = 1 //req.query
+
+    const sql = `DELETE a,b,c
+                 FROM board AS a
+                 INNER JOIN board_hash AS b
+                 INNER JOIN file AS c
+                 ON a.b_idx = b.b_idx = c.b_idx
+                 WHERE a.b_idx = ${b_idx}`
+
+    // 해시태그 테이블에 사용되지않고있는 해시태그 체크하고 삭제해야함
+    // ON DELETE CASCADE ??
+
+    let response = {
+        errno:0
+    }
+
+    try {
+        const [result] = await pool.execute(sql)
+    } catch (error) {
+        console.log(error.message)
+        response = {
+            errno:1
+        }
+    }
+    res.json(response)
+}

--- a/back/routes/board/boardRouter.js
+++ b/back/routes/board/boardRouter.js
@@ -5,5 +5,6 @@ const boardController = require('./boardController.js')
 router.post('/write',boardController.write);
 router.get('/edit',boardController.GetEdit);
 router.post('/edit',boardController.PostEdit);
+router.post('/delete',boardController.delete);
 
 module.exports = router;


### PR DESCRIPTION
- [x] 기능 추가

- [ ] 기능 삭제

- [ ] 버그 수정

- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

변경 사항

게시글 삭제 기능을 추가하였습니다. 

테스트 결과
게시글 삭제시 해당 게시글의 b-idx값을 가진 파일 테이블의 이미지,게시글 해시태그 테이블의 해시태그 번호들이 삭제되나
해시태그 테이블에 사용되지 않고 있는 해시태그를 확인하여 사용하지 않는 해시태그들을 삭제해야 합니다.