### PR TITLE
board / #23 / 게시글 삭제 기능 보완

### DIFF
--- a/back/routes/board/boardController.js
+++ b/back/routes/board/boardController.js
@@ -259,6 +259,13 @@ exports.delete = async (req,res) => {
                  WHERE a.b_idx = ${b_idx}
                  `
 
+    const sql2 = `DELETE a
+                  FROM hashtag AS a
+                  LEFT OUTER JOIN board_hash AS b
+                  ON a.h_idx = b.h_idx
+                  WHERE b.h_idx IS NULL
+                  `
+
     // 해시태그 테이블에 사용되지않고있는 해시태그 체크하고 삭제해야함
     // ON DELETE CASCADE ??
 
@@ -268,7 +275,8 @@ exports.delete = async (req,res) => {
 
     try {
         await pool.execute('SET foreign_key_checks = 0')
-        const [result] = await pool.execute(sql)
+        await pool.execute(sql)
+        await pool.execute(sql2)
         await pool.execute('SET foreign_key_checks = 1')
     } catch (error) {
         console.log(error.message)


### PR DESCRIPTION
- [ ] 기능 추가

- [ ] 기능 삭제

- [x] 버그 수정

- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

변경 사항

게시글을 삭제할 경우 삭제된 해시태그를 더이상 사용하는 게시글이 없을경우 hashtag 테이블에서 해당 해시태그를 삭제한다.

테스트 결과

삭제된 해시태그의 번호가 게시글_해시 테이블에 없을경우 정삭적으로 삭제됩니다.